### PR TITLE
Bug 499165 - more generic solution to registering jax-rs components

### DIFF
--- a/bundles/org.eclipse.ecf.provider.cxf.server/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.cxf.server/META-INF/MANIFEST.MF
@@ -15,9 +15,11 @@ Import-Package: javax.servlet;version="3.1.0",
  org.eclipse.ecf.remoteservice.provider;version="1.0.0",
  org.eclipse.equinox.concurrent.future;version="1.1.0",
  org.osgi.framework;version="1.3.0",
+ org.osgi.service.component.annotations;version="1.2.0";resolution:=optional,
  org.osgi.service.http
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ecf;bundle-version="3.6.0",
  org.eclipse.equinox.common,
  org.apache.cxf.cxf-core
-Service-Component: OSGI-INF/distributionprovider.xml
+Service-Component: OSGI-INF/distributionprovider.xml,
+ OSGI-INF/org.eclipse.ecf.provider.cxf.server.CXFServerDistributionProvider.xml

--- a/bundles/org.eclipse.ecf.provider.cxf.server/OSGI-INF/distributionprovider.xml
+++ b/bundles/org.eclipse.ecf.provider.cxf.server/OSGI-INF/distributionprovider.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" immediate="true" enabled="true" name="org.eclipse.ecf.provider.cxf.server.distribution">
-   <implementation class="org.eclipse.ecf.provider.cxf.server.CXFServerDistributionProvider"/>
-   <reference bind="bindHttpService" cardinality="1..1" interface="org.osgi.service.http.HttpService" name="HttpService" policy="dynamic" unbind="unbindHttpService"/>
-   <service>
-      <provide interface="org.eclipse.ecf.remoteservice.provider.IRemoteServiceDistributionProvider"/>
-   </service>
-</scr:component>

--- a/bundles/org.eclipse.ecf.provider.cxf.server/OSGI-INF/org.eclipse.ecf.provider.cxf.server.CXFServerDistributionProvider.xml
+++ b/bundles/org.eclipse.ecf.provider.cxf.server/OSGI-INF/org.eclipse.ecf.provider.cxf.server.CXFServerDistributionProvider.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" immediate="true" name="org.eclipse.ecf.provider.cxf.server.CXFServerDistributionProvider">
+   <service>
+      <provide interface="org.eclipse.ecf.remoteservice.provider.IRemoteServiceDistributionProvider"/>
+   </service>
+   <implementation class="org.eclipse.ecf.provider.cxf.server.CXFServerDistributionProvider"/>
+</scr:component>

--- a/bundles/org.eclipse.ecf.provider.cxf.server/src/org/eclipse/ecf/provider/cxf/server/CXFServerDistributionProvider.java
+++ b/bundles/org.eclipse.ecf.provider.cxf.server/src/org/eclipse/ecf/provider/cxf/server/CXFServerDistributionProvider.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
-* Copyright (c) 2015 Composent, Inc. and others. All rights reserved. This
+* Copyright (c) 2015, 2016 Composent, Inc. and others. All rights reserved. This
 * program and the accompanying materials are made available under the terms of
 * the Eclipse Public License v1.0 which accompanies this distribution, and is
 * available at http://www.eclipse.org/legal/epl-v10.html
 *
 * Contributors:
 *   Composent, Inc. - initial API and implementation
+*   Erdal Karaca <erdal.karaca.de@gmail.com> - Bug 499165 
 ******************************************************************************/
 package org.eclipse.ecf.provider.cxf.server;
 
@@ -22,11 +23,16 @@ import org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet;
 import org.eclipse.ecf.core.ContainerTypeDescription;
 import org.eclipse.ecf.core.IContainer;
 import org.eclipse.ecf.provider.jaxrs.JaxRSContainerInstantiator;
+import org.eclipse.ecf.provider.jaxrs.server.JaxRSExtensionsRegistry;
 import org.eclipse.ecf.provider.jaxrs.server.JaxRSServerContainer;
 import org.eclipse.ecf.provider.jaxrs.server.JaxRSServerContainer.JaxRSServerRemoteServiceContainerAdapter.JaxRSServerRemoteServiceRegistration;
+import org.eclipse.ecf.remoteservice.provider.IRemoteServiceDistributionProvider;
 import org.eclipse.ecf.provider.jaxrs.server.JaxRSServerDistributionProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
 import org.osgi.service.http.HttpService;
 
+@Component(immediate = true, service = IRemoteServiceDistributionProvider.class)
 public class CXFServerDistributionProvider extends JaxRSServerDistributionProvider {
 
 	public static final String SERVER_CONFIG_NAME = "ecf.jaxrs.cxf.server";
@@ -36,11 +42,14 @@ public class CXFServerDistributionProvider extends JaxRSServerDistributionProvid
 			.getProperty("org.eclipse.ecf.provider.cxf.server.defaultUrlContext", "http://localhost:8080");
 	public static final String ALIAS_PARAM = "alias";
 	public static final String ALIAS_PARAM_DEFAULT = "/cxf";
+	
+	private JaxRSExtensionsRegistry extensionsComponent;
 
 	public CXFServerDistributionProvider() {
 		super();
 	}
 
+	@Activate
 	public void activate() throws Exception {
 		setName(SERVER_CONFIG_NAME);
 		setInstantiator(new JaxRSContainerInstantiator(SERVER_CONFIG_NAME) {
@@ -64,7 +73,7 @@ public class CXFServerDistributionProvider extends JaxRSServerDistributionProvid
 
 					@Override
 					protected HttpService getHttpService() {
-						List<HttpService> svcs = getHttpServices();
+						List<HttpService> svcs = extensionsComponent.getHttpServices();
 						return (svcs == null || svcs.size() == 0) ? null : svcs.get(0);
 					}
 				};

--- a/bundles/org.eclipse.ecf.provider.jaxrs.server/.project
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.server/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/bundles/org.eclipse.ecf.provider.jaxrs.server/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.server/META-INF/MANIFEST.MF
@@ -18,7 +18,11 @@ Import-Package: javax.servlet;version="2.6.0",
  org.eclipse.ecf.remoteservice.provider;version="1.0.0",
  org.eclipse.equinox.concurrent.future,
  org.osgi.framework,
- org.osgi.service.http
+ org.osgi.service.component;version="1.2.2",
+ org.osgi.service.component.annotations;version="1.2.0",
+ org.osgi.service.http,
+ org.osgi.util.tracker;version="1.5.1"
 Require-Bundle: org.eclipse.ecf,
  org.eclipse.equinox.common
 Export-Package: org.eclipse.ecf.provider.jaxrs.server;version="1.0.0"
+Service-Component: OSGI-INF/org.eclipse.ecf.provider.jaxrs.server.JaxRSExtensionsRegistry.xml

--- a/bundles/org.eclipse.ecf.provider.jaxrs.server/OSGI-INF/org.eclipse.ecf.provider.jaxrs.server.JaxRSExtensionsRegistry.xml
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.server/OSGI-INF/org.eclipse.ecf.provider.jaxrs.server.JaxRSExtensionsRegistry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.eclipse.ecf.provider.jaxrs.server.JaxRSExtensionsRegistry">
+   <service>
+      <provide interface="org.eclipse.ecf.provider.jaxrs.server.JaxRSExtensionsRegistry"/>
+   </service>
+   <reference bind="bindHttpService" cardinality="1..n" interface="org.osgi.service.http.HttpService" name="HttpService" policy="static" unbind="unbindHttpService"/>
+   <implementation class="org.eclipse.ecf.provider.jaxrs.server.JaxRSExtensionsRegistry"/>
+</scr:component>

--- a/bundles/org.eclipse.ecf.provider.jaxrs.server/build.properties
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.server/build.properties
@@ -1,4 +1,5 @@
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               OSGI-INF/org.eclipse.ecf.provider.jaxrs.server.JaxRSExtensionsRegistry.xml
 source.. = src/

--- a/bundles/org.eclipse.ecf.provider.jaxrs.server/src/org/eclipse/ecf/provider/jaxrs/server/JaxRSExtensionsRegistry.java
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.server/src/org/eclipse/ecf/provider/jaxrs/server/JaxRSExtensionsRegistry.java
@@ -1,0 +1,165 @@
+/*******************************************************************************
+* Copyright (c) 2016 Erdal Karaca and others. All rights reserved. This
+* program and the accompanying materials are made available under the terms of
+* the Eclipse Public License v1.0 which accompanies this distribution, and is
+* available at http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*   Erdal Karaca <erdal.karaca.de@gmail.com> - initial API and implementation
+******************************************************************************/
+package org.eclipse.ecf.provider.jaxrs.server;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.core.Configurable;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.http.HttpService;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * A registry that handles JAX-RS extensions. Consumers are expected to call
+ * {@link #bindConfigurable(Configurable)} to register the extensions known to
+ * this registry. Note that the JAX-RS {@link Configurable} interface has no
+ * unregister method, thus, unbinding a configurable is not possible.
+ * 
+ * @author Erdal Karaca
+ *
+ */
+@Component(service = JaxRSExtensionsRegistry.class)
+public class JaxRSExtensionsRegistry {
+	private static class Extension {
+		public int priority = 0;
+		public Object jaxRsComponent;
+	}
+
+	private static final String JAX_RS_EXTENSION = "jaxRsExtension";
+	private static final String JAX_RS_EXTENSION_PRIO = "bindingPriority";
+
+	private List<HttpService> httpServices = Collections.synchronizedList(new ArrayList<HttpService>());
+	private List<WeakReference<Configurable<?>>> configs = Collections
+			.synchronizedList(new ArrayList<WeakReference<Configurable<?>>>());
+	private ServiceTracker<Object, Object> tracker;
+
+	@Activate
+	public void activate(ComponentContext cc) throws InvalidSyntaxException {
+		final BundleContext bundleContext = cc.getBundleContext();
+		Filter filter = bundleContext
+				.createFilter("(&(" + Constants.OBJECTCLASS + "=*)(" + JAX_RS_EXTENSION + "=true))");
+		tracker = new ServiceTracker<>(bundleContext, filter, new ServiceTrackerCustomizer<Object, Object>() {
+
+			@Override
+			public Object addingService(ServiceReference<Object> reference) {
+				Extension extension = new Extension();
+				extension.jaxRsComponent = bundleContext.getService(reference);
+
+				try {
+					extension.priority = Integer.parseInt((String) reference.getProperty(JAX_RS_EXTENSION_PRIO));
+				} catch (NumberFormatException e) {
+					extension.priority = 0;
+				}
+
+				handleAddition(extension);
+				return extension;
+			}
+
+			@Override
+			public void modifiedService(ServiceReference<Object> reference, Object service) {
+			}
+
+			@Override
+			public void removedService(ServiceReference<Object> reference, Object service) {
+				// we should somehow unregister the service from the
+				// Configurable, but the Configurable interface has no
+				// unregister methods
+			}
+		});
+		tracker.open();
+	}
+
+	private void handleAddition(Extension extension) {
+		// lock the list to not miss any configs that might be added while
+		// traversing (iterating a synced list is not thread safe)
+		synchronized (configs) {
+			for (WeakReference<Configurable<?>> weakReference : new ArrayList<>(configs)) {
+				Configurable<?> config = weakReference.get();
+
+				if (config == null) {
+					configs.remove(weakReference);
+				} else {
+					registerExtension(config, extension);
+				}
+			}
+		}
+	}
+
+	@Deactivate
+	public void deactivate() {
+		tracker.close();
+	}
+
+	@Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE)
+	public void bindHttpService(HttpService httpService) {
+		if (httpService != null)
+			httpServices.add(httpService);
+	}
+
+	public void unbindHttpService(HttpService httpService) {
+		if (httpService != null)
+			httpServices.remove(httpService);
+	}
+
+	public List<HttpService> getHttpServices() {
+		return Collections.unmodifiableList(httpServices);
+	}
+
+	private List<Extension> getJaxRSExtensions() {
+		List<Extension> extensions = new ArrayList<>();
+		Object[] services = tracker.getServices();
+
+		if (services != null) {
+			for (Object serviceObj : services) {
+				extensions.add((Extension) serviceObj);
+			}
+		}
+
+		return extensions;
+	}
+
+	/**
+	 * Call this method to manage the provided {@link Configurable} instance.
+	 * The registry will handle dynamic extension additions. Note that the
+	 * provided configurable will be held as a weak reference.
+	 * 
+	 * @param config
+	 *            the configurable to manage by this registry
+	 */
+	public void bindConfigurable(Configurable<?> config) {
+		List<Extension> jaxRSExtensions = getJaxRSExtensions();
+
+		for (Extension extension : jaxRSExtensions) {
+			registerExtension(config, extension);
+		}
+
+		configs.add(new WeakReference<Configurable<?>>(config));
+	}
+
+	private void registerExtension(Configurable<?> config, Extension extension) {
+		config.register(extension.jaxRsComponent, extension.priority);
+	}
+
+}

--- a/bundles/org.eclipse.ecf.provider.jaxrs.server/src/org/eclipse/ecf/provider/jaxrs/server/JaxRSServerDistributionProvider.java
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.server/src/org/eclipse/ecf/provider/jaxrs/server/JaxRSServerDistributionProvider.java
@@ -1,33 +1,21 @@
 /*******************************************************************************
-* Copyright (c) 2015 Composent, Inc. and others. All rights reserved. This
+* Copyright (c) 2015, 2016 Composent, Inc. and others. All rights reserved. This
 * program and the accompanying materials are made available under the terms of
 * the Eclipse Public License v1.0 which accompanies this distribution, and is
 * available at http://www.eclipse.org/legal/epl-v10.html
 *
 * Contributors:
 *   Composent, Inc. - initial API and implementation
+*   Erdal Karaca <erdal.karaca.de@gmail.com> - Bug 499165 
 ******************************************************************************/
 package org.eclipse.ecf.provider.jaxrs.server;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import javax.ws.rs.ext.MessageBodyWriter;
-
 import org.eclipse.ecf.core.provider.IContainerInstantiator;
 import org.eclipse.ecf.remoteservice.provider.RemoteServiceDistributionProvider;
-import org.osgi.service.http.HttpService;
 
 public class JaxRSServerDistributionProvider extends RemoteServiceDistributionProvider {
-	
-	private Set<MessageBodyWriter<Object>> messageBodyWriters = Collections
-			.synchronizedSet(new HashSet<MessageBodyWriter<Object>>());
 
 	protected JaxRSServerDistributionProvider() {
-
 	}
 
 	protected JaxRSServerDistributionProvider(String name, IContainerInstantiator instantiator) {
@@ -41,33 +29,5 @@ public class JaxRSServerDistributionProvider extends RemoteServiceDistributionPr
 	protected JaxRSServerDistributionProvider(String name, IContainerInstantiator instantiator, String description,
 			boolean server) {
 		super(name, instantiator, description, server);
-	}
-
-	private List<HttpService> httpServices = Collections.synchronizedList(new ArrayList<HttpService>());
-
-	public void bindHttpService(HttpService httpService) {
-		if (httpService != null)
-			httpServices.add(httpService);
-	}
-
-	public void unbindHttpService(HttpService httpService) {
-		if (httpService != null)
-			httpServices.remove(httpService);
-	}
-
-	protected List<HttpService> getHttpServices() {
-		return httpServices;
-	}
-
-	public void addMessageBodyWriter(MessageBodyWriter<Object> writer) {
-		messageBodyWriters.add(writer);
-	}
-
-	public void removeMessageBodyWriter(MessageBodyWriter<Object> writer) {
-		messageBodyWriters.remove(writer);
-	}
-	
-	public Set<MessageBodyWriter<Object>> getMessageBodyWriters() {
-		return messageBodyWriters;
 	}
 }

--- a/bundles/org.eclipse.ecf.provider.jersey.server/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.jersey.server/META-INF/MANIFEST.MF
@@ -18,10 +18,12 @@ Import-Package: javax.servlet,
  org.glassfish.jersey.server.spi;version="2.14.0",
  org.glassfish.jersey.servlet;version="2.14.0",
  org.osgi.framework,
+ org.osgi.service.component.annotations;version="1.2.0";resolution:=optional,
  org.osgi.service.http;version="1.2.1"
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ecf,
  org.eclipse.equinox.common
-Service-Component: OSGI-INF/distributionprovider.xml
+Service-Component: OSGI-INF/distributionprovider.xml,
+ OSGI-INF/org.eclipse.ecf.provider.jersey.server.JerseyServerDistributionProvider.xml
 Provide-Capability: osgi.remoteserviceadmin.distribution; configs:List<String>="ecf.jaxrs.jersey.server"; version:Version=1.0
 Export-Package: org.eclipse.ecf.provider.jersey.server;version="1.0.0"

--- a/bundles/org.eclipse.ecf.provider.jersey.server/OSGI-INF/distributionprovider.xml
+++ b/bundles/org.eclipse.ecf.provider.jersey.server/OSGI-INF/distributionprovider.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" immediate="false" name="org.eclipse.ecf.provider.jersey.server.distributionprovider">
-   <implementation class="org.eclipse.ecf.provider.jersey.server.JerseyServerDistributionProvider"/>
-   <reference bind="bindHttpService" cardinality="1..1" interface="org.osgi.service.http.HttpService" name="HttpService" policy="static" unbind="unbindHttpService"/>
-   <service>
-      <provide interface="org.eclipse.ecf.remoteservice.provider.IRemoteServiceDistributionProvider"/>
-   </service>
-   <reference bind="addMessageBodyWriter" cardinality="0..n" interface="javax.ws.rs.ext.MessageBodyWriter" name="MessageBodyWriter" policy="dynamic" unbind="removeMessageBodyWriter"/>
-</scr:component>

--- a/bundles/org.eclipse.ecf.provider.jersey.server/OSGI-INF/org.eclipse.ecf.provider.jersey.server.JerseyServerDistributionProvider.xml
+++ b/bundles/org.eclipse.ecf.provider.jersey.server/OSGI-INF/org.eclipse.ecf.provider.jersey.server.JerseyServerDistributionProvider.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" immediate="true" name="org.eclipse.ecf.provider.jersey.server.JerseyServerDistributionProvider">
+   <service>
+      <provide interface="org.eclipse.ecf.remoteservice.provider.IRemoteServiceDistributionProvider"/>
+   </service>
+   <reference bind="setExtensionsComponent" cardinality="1..1" interface="org.eclipse.ecf.provider.jaxrs.server.JaxRSExtensionsRegistry" name="ExtensionsComponent" policy="static"/>
+   <implementation class="org.eclipse.ecf.provider.jersey.server.JerseyServerDistributionProvider"/>
+</scr:component>


### PR DESCRIPTION
- jax-rs extensions/components are now consumed from the OSGi service registry
- refactored manual DS definition files to annotations based definition