### PR TITLE
Update to Java 11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/bundles/org.eclipse.ecf.provider.cxf.client/.classpath
+++ b/bundles/org.eclipse.ecf.provider.cxf.client/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/bundles/org.eclipse.ecf.provider.cxf.client/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.ecf.provider.cxf.client/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.eclipse.ecf.provider.cxf.client/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.cxf.client/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: ECF Dist Provider - CXF Jax-RS Client
 Bundle-SymbolicName: org.eclipse.ecf.provider.cxf.client
 Bundle-Version: 1.5.0.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: com.fasterxml.jackson.core;version="2.9.2",
  com.fasterxml.jackson.databind;version="2.9.2",

--- a/bundles/org.eclipse.ecf.provider.cxf.server/.classpath
+++ b/bundles/org.eclipse.ecf.provider.cxf.server/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/bundles/org.eclipse.ecf.provider.cxf.server/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.ecf.provider.cxf.server/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -11,4 +11,4 @@ org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.eclipse.ecf.provider.cxf.server/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.cxf.server/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: ECF Dist Provider - CXF Server
 Bundle-SymbolicName: org.eclipse.ecf.provider.cxf.server
 Bundle-Version: 1.8.2.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: com.fasterxml.jackson.core;version="2.9.2",
  com.fasterxml.jackson.databind;version="2.9.2",
  com.fasterxml.jackson.jaxrs.base;version="2.9.8",

--- a/bundles/org.eclipse.ecf.provider.jaxrs.client/.classpath
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.client/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/bundles/org.eclipse.ecf.provider.jaxrs.client/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.client/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.eclipse.ecf.provider.jaxrs.client/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.client/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Import-Package: com.fasterxml.jackson.core;version="2.9.2",
  org.eclipse.ecf.remoteservice.util;version="8.3.0",
  org.eclipse.equinox.concurrent.future;version="1.1.0",
  org.osgi.framework
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.ecf.provider.jaxrs.client;version="1.1.0"
 Automatic-Module-Name: org.eclipse.ecf.provider.jaxrs.client

--- a/bundles/org.eclipse.ecf.provider.jaxrs.server/.classpath
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.server/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/bundles/org.eclipse.ecf.provider.jaxrs.server/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.server/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.eclipse.ecf.provider.jaxrs.server/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.jaxrs.server/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: ECF JaxRS Server Support
 Bundle-SymbolicName: org.eclipse.ecf.provider.jaxrs.server
 Bundle-Version: 1.11.1.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: com.fasterxml.jackson.core;version="2.9.2",
  com.fasterxml.jackson.databind;version="2.9.2",

--- a/bundles/org.eclipse.ecf.provider.jaxrs/.classpath
+++ b/bundles/org.eclipse.ecf.provider.jaxrs/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/bundles/org.eclipse.ecf.provider.jaxrs/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.ecf.provider.jaxrs/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.eclipse.ecf.provider.jaxrs/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.jaxrs/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: ECF Distribution Provider - Jax RS Support
 Bundle-SymbolicName: org.eclipse.ecf.provider.jaxrs
 Bundle-Version: 1.7.1.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: com.fasterxml.jackson.core;version="2.9.2",
  com.fasterxml.jackson.databind;version="2.9.2",

--- a/bundles/org.eclipse.ecf.provider.jersey.client/.classpath
+++ b/bundles/org.eclipse.ecf.provider.jersey.client/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/bundles/org.eclipse.ecf.provider.jersey.client/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.ecf.provider.jersey.client/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.eclipse.ecf.provider.jersey.client/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.jersey.client/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: ECF Jersey Remote Services Client
 Bundle-SymbolicName: org.eclipse.ecf.provider.jersey.client
 Bundle-Version: 1.8.2.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: com.fasterxml.jackson.core;version="2.9.2",
  com.fasterxml.jackson.databind;version="2.9.2",

--- a/bundles/org.eclipse.ecf.provider.jersey.server/.classpath
+++ b/bundles/org.eclipse.ecf.provider.jersey.server/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/bundles/org.eclipse.ecf.provider.jersey.server/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.ecf.provider.jersey.server/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.eclipse.ecf.provider.jersey.server/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.jersey.server/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: ECF Dist Provider - Jersey Jax RS Server
 Bundle-SymbolicName: org.eclipse.ecf.provider.jersey.server
 Bundle-Version: 1.11.1.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: com.fasterxml.jackson.annotation;version="2.10.1",
  com.fasterxml.jackson.core;version="2.6.2",
  com.fasterxml.jackson.databind;version="2.6.2",

--- a/bundles/org.eclipse.ecf.provider.resteasy.client/.classpath
+++ b/bundles/org.eclipse.ecf.provider.resteasy.client/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.ecf.provider.resteasy.client/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.ecf.provider.resteasy.client/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.eclipse.ecf.provider.resteasy.client/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ecf.provider.resteasy.client/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: ECF Remote Service Distribution Provider based upon RestEasy
 Bundle-SymbolicName: org.eclipse.ecf.provider.resteasy.client
 Bundle-Version: 3.0.9.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.equinox.common;bundle-version="3.7.0",
  org.eclipse.ecf;bundle-version="3.5.0"

--- a/examples/com.mycorp.examples.student.client.filediscovery/.classpath
+++ b/examples/com.mycorp.examples.student.client.filediscovery/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/examples/com.mycorp.examples.student.client.filediscovery/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/com.mycorp.examples.student.client.filediscovery/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/com.mycorp.examples.student.client.filediscovery/META-INF/MANIFEST.MF
+++ b/examples/com.mycorp.examples.student.client.filediscovery/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Student Remote Service Filediscovery
 Bundle-SymbolicName: com.mycorp.examples.student.client.filediscovery
 Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Remote-Service: edef/studentserviceEDEF.xml
 Automatic-Module-Name: com.mycorp.examples.student.client.filediscovery

--- a/examples/com.mycorp.examples.student.client/.classpath
+++ b/examples/com.mycorp.examples.student.client/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/examples/com.mycorp.examples.student.client/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/com.mycorp.examples.student.client/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/com.mycorp.examples.student.client/META-INF/MANIFEST.MF
+++ b/examples/com.mycorp.examples.student.client/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Example Student Remote Service Client
 Bundle-SymbolicName: com.mycorp.examples.student.client
 Bundle-Version: 2.2.1.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: com.mycorp.examples.student;version="1.0.0",
  org.osgi.service.component.annotations;version="1.2.0";resolution:=optional

--- a/examples/com.mycorp.examples.student.client/launch/StudentClient.zeroconf.basicauth.jersey.product
+++ b/examples/com.mycorp.examples.student.client/launch/StudentClient.zeroconf.basicauth.jersey.product
@@ -22,7 +22,7 @@
    </launcher>
 
    <vm>
-      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</windows>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
    </vm>
 
    <plugins>

--- a/examples/com.mycorp.examples.student.client/launch/StudentClient.zeroconf.jersey.product
+++ b/examples/com.mycorp.examples.student.client/launch/StudentClient.zeroconf.jersey.product
@@ -22,7 +22,7 @@
    </launcher>
 
    <vm>
-      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</windows>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
    </vm>
 
    <plugins>

--- a/examples/com.mycorp.examples.student.remoteservice.host/.classpath
+++ b/examples/com.mycorp.examples.student.remoteservice.host/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/examples/com.mycorp.examples.student.remoteservice.host/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/com.mycorp.examples.student.remoteservice.host/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/com.mycorp.examples.student.remoteservice.host/META-INF/MANIFEST.MF
+++ b/examples/com.mycorp.examples.student.remoteservice.host/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: ECF Example Student Service Host
 Bundle-SymbolicName: com.mycorp.examples.student.remoteservice.host
 Bundle-Version: 2.3.1.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: com.mycorp.examples.student;version="1.0.0",
  javax.ws.rs;version="2.0.1",
  javax.ws.rs.client;version="2.0.1",

--- a/examples/com.mycorp.examples.student/.classpath
+++ b/examples/com.mycorp.examples.student/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/examples/com.mycorp.examples.student/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/com.mycorp.examples.student/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/com.mycorp.examples.student/META-INF/MANIFEST.MF
+++ b/examples/com.mycorp.examples.student/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: ECF Example Student Service API
 Bundle-SymbolicName: com.mycorp.examples.student
 Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: javax.ws.rs;version="2.0.1",
  javax.ws.rs.core;version="2.0.1",
  javax.xml.bind.annotation;version="2.2.12"

--- a/examples/org.eclipse.ecf.example.jersey.client.basicauth/.classpath
+++ b/examples/org.eclipse.ecf.example.jersey.client.basicauth/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/examples/org.eclipse.ecf.example.jersey.client.basicauth/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/org.eclipse.ecf.example.jersey.client.basicauth/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/org.eclipse.ecf.example.jersey.client.basicauth/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ecf.example.jersey.client.basicauth/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.ecf.example.jersey.client.basicauth
 Bundle-Version: 1.0.1.qualifier
 Bundle-Vendor: Eclipse.org - ECF
 Automatic-Module-Name: org.eclipse.ecf.example.jersey.client.basicauth
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.ws.rs.client,
  javax.ws.rs.core,

--- a/examples/org.eclipse.ecf.example.jersey.server.basicauth/.classpath
+++ b/examples/org.eclipse.ecf.example.jersey.server.basicauth/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/examples/org.eclipse.ecf.example.jersey.server.basicauth/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/org.eclipse.ecf.example.jersey.server.basicauth/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/org.eclipse.ecf.example.jersey.server.basicauth/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ecf.example.jersey.server.basicauth/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.ecf.example.jersey.server.basicauth
 Bundle-Version: 1.0.2.qualifier
 Bundle-Vendor: Eclipse.org - ECF
 Automatic-Module-Name: org.eclipse.ecf.example.jersey.server.basicauth
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.ws.rs.container,
  javax.ws.rs.core,

--- a/examples/org.eclipse.ecf.example.jersey.server.objectmapper/.classpath
+++ b/examples/org.eclipse.ecf.example.jersey.server.objectmapper/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.ecf.example.jersey.server.objectmapper/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/org.eclipse.ecf.example.jersey.server.objectmapper/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/org.eclipse.ecf.example.jersey.server.objectmapper/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ecf.example.jersey.server.objectmapper/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.ecf.example.jersey.server.objectmapper
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse.org - ECF
 Automatic-Module-Name: org.eclipse.ecf.example.jersey.server.objectmapper
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: com.fasterxml.jackson.core;version="2.10.1",
  com.fasterxml.jackson.databind;version="2.10.1",
  javax.ws.rs.ext;version="2.1.5",

--- a/examples/org.eclipse.ecf.provider.jersey.ext.example/.classpath
+++ b/examples/org.eclipse.ecf.provider.jersey.ext.example/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/examples/org.eclipse.ecf.provider.jersey.ext.example/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/org.eclipse.ecf.provider.jersey.ext.example/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/org.eclipse.ecf.provider.jersey.ext.example/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ecf.provider.jersey.ext.example/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.ecf.provider.jersey.ext.example
 Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse.org - ECF
 Automatic-Module-Name: org.eclipse.ecf.provider.jersey.ext.example
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.servlet;version="3.1.0",
  javax.ws.rs.core;version="2.1.5",

--- a/examples/org.eclipse.ecf.provider.jersey.server.example.student.extensions/.classpath
+++ b/examples/org.eclipse.ecf.provider.jersey.server.example.student.extensions/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/examples/org.eclipse.ecf.provider.jersey.server.example.student.extensions/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/org.eclipse.ecf.provider.jersey.server.example.student.extensions/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/org.eclipse.ecf.provider.jersey.server.example.student.extensions/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ecf.provider.jersey.server.example.student.extensions/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Example Jersey Extensions for Student API
 Bundle-SymbolicName: org.eclipse.ecf.provider.jersey.server.example.student.extensions
 Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse.org - ECF
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: com.mycorp.examples.student;version="1.0.0",
  javax.ws.rs;version="2.0.1",
  javax.ws.rs.core;version="2.0.1",

--- a/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.consumer/.classpath
+++ b/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.consumer/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.consumer/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.consumer/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.consumer/META-INF/MANIFEST.MF
+++ b/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.consumer/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.ecf.example.spacex.launch.api.consumer
 Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse.org - ECF
 Automatic-Module-Name: org.eclipse.ecf.example.spacex.launch.api.consumer
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.ecf.example.spacex.launch.api,
  org.osgi.service.component.annotations;resolution:=optional
 Bundle-ActivationPolicy: lazy

--- a/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.test/.classpath
+++ b/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src">
 		<attributes>

--- a/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.test/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.test/META-INF/MANIFEST.MF
+++ b/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api.test/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Modular Mind, Ltd.
 Fragment-Host: org.eclipse.ecf.example.spacex.launch.api;bundle-version="1.0.0"
 Automatic-Module-Name: org.eclipse.ecf.example.spacex.launch.api.test
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.osgi.framework;version="1.9.0",
  org.osgi.util.tracker;version="1.5.2"
 Require-Bundle: org.junit.jupiter.api

--- a/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api/.classpath
+++ b/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api/META-INF/MANIFEST.MF
+++ b/examples/spacex-launch-service/org.eclipse.ecf.example.spacex.launch.api/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: SpaceX REST Launch Service via JAX-RS
 Bundle-SymbolicName: org.eclipse.ecf.example.spacex.launch.api
 Bundle-Version: 1.1.0.qualifier
 Automatic-Module-Name: oreg.eclipse.ecf.example.spacex.launch.api
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: com.fasterxml.jackson.annotation;version="2.10.1",
  com.fasterxml.jackson.databind;version="2.10.1",
  com.fasterxml.jackson.databind.annotation;version="2.10.1",


### PR DESCRIPTION
It is the oldest supported LTS version. [Tycho requires it since version 2](https://wiki.eclipse.org/Tycho/Release_Notes/2.0#Requires_Java_11)